### PR TITLE
flex-wrap pour mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -19,7 +19,7 @@
 body {
     background-color: var(--color-primary);
     display: flex;
-    flex-direction: row;
+    flex-wrap: wrap;
     justify-content: space-around;
 }
 


### PR DESCRIPTION
Corrige l'affichage du menu principal sur téléphone portable avec un `flex-wrap` des familles 😉 